### PR TITLE
fs-extra should be a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "babel-plugin-transform-runtime": ">= 6.8.0",
+    "fs-extra": "^0.30.0",
     "node-sass": ">= 3.8.0",
     "rollup-pluginutils": ">= 1.3.1"
   },
@@ -35,7 +36,6 @@
     "ava": "^0.16.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-preset-es2015-rollup": "^1.1.1",
-    "fs-extra": "^0.30.0",
     "rollup": ">= 0.26.3",
     "rollup-plugin-babel": "^2.4.0"
   }


### PR DESCRIPTION
Since it's used other than during the build process, the fs-extra package is actually not a dev dependency.
