### PR TITLE
Fix install by updating to best practices

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,15 @@
 {
     "plugins": [
+        "external-helpers",
         "transform-async-to-generator",
         "transform-runtime"
     ],
     "presets": [
-        "es2015-rollup"
+        [
+            "es2015",
+            {
+                "modules": false
+            }
+        ]
     ]
 }

--- a/dist/rollup-plugin-sass.js
+++ b/dist/rollup-plugin-sass.js
@@ -184,17 +184,20 @@ function plugin() {
 
               case 12:
                 if (!(!options.insert && dest)) {
-                  _context2.next = 15;
+                  _context2.next = 17;
                   break;
                 }
 
                 if (dest.endsWith('.js')) {
                   dest = dest.slice(0, -3);
                 }
+                dest = dest + '.css';
+                fsExtra.ensureFileSync(dest, function (err) {
+                  if (err) throw err;
+                });
+                return _context2.abrupt('return', fs.writeFileSync(dest, css));
 
-                return _context2.abrupt('return', fs.writeFileSync(dest + '.css', css));
-
-              case 15:
+              case 17:
               case 'end':
                 return _context2.stop();
             }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublish": "npm run test",
     "pretest": "npm run build",
-    "build": "node build/build.js",
+    "build": "rollup -c",
     "test": "ava test/index.js -s"
   },
   "standard": {
@@ -39,8 +39,9 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-preset-es2015": "^6.22.0",
     "rollup": ">= 0.26.3",
     "rollup-plugin-babel": "^2.4.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,9 @@
-const rollup = require('rollup').rollup
-const babel = require('rollup-plugin-babel')
+import babel from 'rollup-plugin-babel'
 
-rollup({
+export default {
   entry: './src/index.js',
+  format: 'cjs',
+  dest: 'dist/rollup-plugin-sass.js',
   external: [
     'babel-runtime/core-js/json/stringify',
     'babel-runtime/core-js/object/assign',
@@ -20,9 +21,4 @@ rollup({
       runtimeHelpers: true
     })
   ]
-}).then(function (bundle) {
-  bundle.write({
-    dest: 'dist/rollup-plugin-sass.js',
-    format: 'cjs'
-  })
-}).catch(console.error)
+}


### PR DESCRIPTION
Fixes a couple things to use Rollup's updated best practices (also fixed the broken install for me).

1. Switch from `babel-preset-es2015-rollup` to `babel-preset-es2015` with `"modules": false`. [Recommended](https://github.com/rollup/rollup-plugin-babel#modules).

2. Include `external-helpers` in .babelrc. [Recommended](https://github.com/rollup/rollup-plugin-babel#helpers).

3. Switch from `build/build.js` to `rollup.config.js` [Recommended](http://rollupjs.org/guide/#using-config-files).