### PR TITLE
Use the file option insetad of data for renderSync

### DIFF
--- a/dist/rollup-plugin-sass.js
+++ b/dist/rollup-plugin-sass.js
@@ -65,7 +65,7 @@ function plugin() {
     },
     transform: function () {
       var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime.mark(function _callee(code, id) {
-        var paths, sassConfig, css, _code;
+        var paths, baseConfig, sassConfig, css, _code;
 
         return _regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
@@ -80,32 +80,33 @@ function plugin() {
 
               case 2:
                 paths = [path.dirname(id), process.cwd()];
-                sassConfig = _Object$assign({ data: '' + prependSass + code }, options.options);
+                baseConfig = prependSass ? { data: '' + prependSass + code } : { file: id };
+                sassConfig = _Object$assign(baseConfig, options.options);
 
 
                 sassConfig.includePaths = sassConfig.includePaths ? sassConfig.includePaths.concat(paths) : paths;
 
-                _context.prev = 5;
+                _context.prev = 6;
                 css = nodeSass.renderSync(sassConfig).css.toString();
                 _code = '';
 
                 if (!css.trim()) {
-                  _context.next = 16;
+                  _context.next = 17;
                   break;
                 }
 
                 if (!util.isFunction(options.processor)) {
-                  _context.next = 13;
+                  _context.next = 14;
                   break;
                 }
 
-                _context.next = 12;
+                _context.next = 13;
                 return options.processor(css, id);
 
-              case 12:
+              case 13:
                 css = _context.sent;
 
-              case 13:
+              case 14:
                 if (styleMaps[id]) {
                   styleMaps[id].content = css;
                 } else {
@@ -123,23 +124,23 @@ function plugin() {
                   _code = '"";';
                 }
 
-              case 16:
+              case 17:
                 return _context.abrupt('return', {
                   code: 'export default ' + _code + ';',
                   map: { mappings: '' }
                 });
 
-              case 19:
-                _context.prev = 19;
-                _context.t0 = _context['catch'](5);
+              case 20:
+                _context.prev = 20;
+                _context.t0 = _context['catch'](6);
                 throw _context.t0;
 
-              case 22:
+              case 23:
               case 'end':
                 return _context.stop();
             }
           }
-        }, _callee, this, [[5, 19]]);
+        }, _callee, this, [[6, 20]]);
       }));
 
       function transform(_x2, _x3) {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,11 @@ export default function plugin (options = {}) {
       }
 
       const paths = [dirname(id), process.cwd()];
-      const sassConfig = Object.assign({ data: `${prependSass}${code}` }, options.options);
+      const baseConfig = prependSass
+        ? { data: `${prependSass}${code}` }
+        : { file: id };
+
+      const sassConfig = Object.assign(baseConfig, options.options);
 
       sassConfig.includePaths = sassConfig.includePaths
         ? sassConfig.includePaths.concat(paths)

--- a/test/assets/actual_c.sass
+++ b/test/assets/actual_c.sass
@@ -1,5 +1,4 @@
-$color_blue: blue;
+$color_blue: blue
 
-body {
-  color: $color_blue;
-}
+body
+  color: $color_blue


### PR DESCRIPTION
### What does this PR do?

As I mentioned on #45, when you use `sourceMapEmbed`, you can't the path to the original sources because the [node-sass](http://npmjs.com/package/node-sass) `renderSync` call was made using the `data` option, which is a string with the whole SASS, so the map source is set to `stdin`.

In order to get the real sources on a source map, you need to use the `file` option, instead of `data`, with the path of the file that will be processed.

Now, the reason `renderSync` is called with `data` is because the plugin allows you to send a `data` option with custom SASS code that will be prepended to the contents of the file.

Finally, the change I'm proposing is that, when you use the `data` option, the plugin will behave as always and call `renderSync` with the whole code; but if you don't use `data`, the plugin will call `renderSync` with the `file` option.

If you noticed that I changed a test asset file, I did it because its extension was `.sass` but the code was `SCSS`, and when you use `file`, you need to use the syntax that matches the extension of the file.

### How should it be tested manually?

Use the plugin with the `options.sourceMapEmbed` option set to `true`, and don't include a `data` option.
The generated file will include a huge comment with the source map encoded on Base64; you can use [base64decode.org](https://www.base64decode.org) to decode that it, and once you do it, you'll see that `sources` now points to the real files that were encoded. 

And don't forget to `npm test`.
