### PR TITLE
Add support for CSS modules names on the processor

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ export default {
     'babel-runtime/regenerator',
     'babel-runtime/core-js/json/stringify',
     'babel-runtime/core-js/object/assign',
+    'babel-runtime/core-js/object/keys',
     'babel-runtime/helpers/asyncToGenerator',
     'path',
     'fs',

--- a/src/style.js
+++ b/src/style.js
@@ -1,10 +1,11 @@
 /*
  * Create a style tag and append to head tag
  *
- * @param {String} css style
+ * @param {String} css     style
+ * @param {Object} [names] The modules names
  * @return {String} css style
  */
-function insertStyle (css) {
+function insertStyle (css, names) {
   if (!css) {
     return
   }
@@ -18,9 +19,9 @@ function insertStyle (css) {
   style.innerHTML = css
   document.head.appendChild(style)
 
-  return css
+  return names || css
 }
 
 export {
-    insertStyle
+  insertStyle
 }

--- a/src/style.js
+++ b/src/style.js
@@ -1,11 +1,10 @@
 /*
  * Create a style tag and append to head tag
  *
- * @param {String} css     style
- * @param {Object} [names] The modules names
+ * @param {String} css style
  * @return {String} css style
  */
-function insertStyle (css, names) {
+function insertStyle (css) {
   if (!css) {
     return
   }
@@ -19,9 +18,9 @@ function insertStyle (css, names) {
   style.innerHTML = css
   document.head.appendChild(style)
 
-  return names || css
+  return css
 }
 
 export {
-  insertStyle
+    insertStyle
 }


### PR DESCRIPTION
### What does this PR do?

> TL;DR: Adds support for importing CSS modules names if provided by a processor.

While using the plugin and `postcss` to implement CSS modules, I found out that there was no way to obtain the generated names/aliases as the process was being made "on the fly".

So I'm proposing the following changes:

- The `processor` function can now return either a string or an object with the keys `css` and `names` (<- check last point).
- The function that inserts the styles on the `head` now can receive a second parameter with the names, and if its value is _truthy_, it will return that instead of the code.
- There's a new option called `modulesVariable` with a default value of `names`. This option defines the name of the exported variable for the names and the property the processor has to return in order to send the names.

This is a _"feature change"_, it doesn't break any of the existing functionality.

### How should it be tested manually?

For a real example, you'll first need to install `postcss` and `postcss-modules` in order to implement CSS modules.

Then, you can configure Rollup like this:

```js
const postcss = require('postcss');
const postcssModules = require('postcss-modules');
const sass = require('rollup-plugin-sass');

module.exports = {
  input: { ... },
  output: { ... },
  plugins: [
    sass({
      processor: (code) => {
        let names;
        return postcss([
          postcssModules({
            getJSON: (filename, json) => {
              names = json;
            },
          }),
        ])
        .process(code)
        .then((css) => ({
          css,
          names,
        });
      }
    }),
  ],
}
```

The `postcss-modules` plugin originally writes a JSON file on the same directory as the file, but because we are processing it as a string in order to return it to the plugin, we don't have a file, so we need to use the `getJSON` option to retrieve the names and be able to send them with the code.

Now, if you are using `insert: true`:

```js
import styles from 'stylesheet.scss';
```

`styles` will be the dictionary with the CSS modules names.

Otherwise, you could do:

```js
import styles, { names } from 'stylesheet.scss';
```

`styles` has the styles and `names` is the dictionary with the CSS modules names.


### Extras

- I didn't add tests for this because I'm not entirely sure how to write a test with Ava for this, I don't have a lot of experience with it.
- I didn't update the `README.md` because I wasn't sure where to add it, since CSS modules is not the feature itself, but an added support for the processor feature.