### PR TITLE
Allow different runtimes to be passed in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Otherwise, you could do:
 import style, { foo, bar } from 'stylesheet';
 ```
 
+### `runtime`
+
++ Type: `Object` _(default: nodeSass)_
+
+If you specify an object, it will be used instead of `node-sass`. You can use this to pass a different sass processor (for example the `sass` npm package for a completely Javascript build).
+
 ### `options`
 
 + Type: `Object`

--- a/dist/rollup-plugin-sass.js
+++ b/dist/rollup-plugin-sass.js
@@ -54,6 +54,8 @@ function plugin() {
   options.output = options.output || false;
   options.insert = options.insert || false;
 
+  var sassRuntime = options.runtime || nodeSass;
+
   return {
     name: 'sass',
 
@@ -81,7 +83,7 @@ function plugin() {
                 paths = [path.dirname(id), process.cwd()];
                 customizedSassOptions = options.options || {};
                 _context.next = 7;
-                return pify(nodeSass.render.bind(nodeSass))(_Object$assign({}, customizedSassOptions, {
+                return pify(sassRuntime.render.bind(sassRuntime))(_Object$assign({}, customizedSassOptions, {
                   file: id,
                   data: customizedSassOptions.data && '' + customizedSassOptions.data + code,
                   indentedSyntax: MATHC_SASS_FILENAME_RE.test(id),

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ export default function plugin(options = {}) {
   options.output = options.output || false;
   options.insert = options.insert || false;
 
+  const sassRuntime = options.runtime || nodeSass;
+
   return {
     name: 'sass',
 
@@ -37,7 +39,7 @@ export default function plugin(options = {}) {
       try {
         const paths = [dirname(id), process.cwd()];
         const customizedSassOptions = options.options || {};
-        const res = await pify(nodeSass.render.bind(nodeSass))(Object.assign({}, customizedSassOptions, {
+        const res = await pify(sassRuntime.render.bind(sassRuntime))(Object.assign({}, customizedSassOptions, {
           file: id,
           data: customizedSassOptions.data && `${customizedSassOptions.data}${code}`,
           indentedSyntax: MATHC_SASS_FILENAME_RE.test(id),


### PR DESCRIPTION
Allows using the `sass` library (pure Javascript version).

It's actually slightly faster on my machine (by 1 second)