### PR TITLE
Allow options.exclude to be empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,11 @@ const MATCH_SASS_FILENAME_RE = /\.sass$/;
 const MATCH_NODE_MODULE_RE = /^~([a-z0-9]|@).+/i;
 
 export default function plugin(options = {}) {
-  const filter = createFilter(options.include || [ '**/*.sass', '**/*.scss' ], options.exclude || 'node_modules/**');
+  const {
+    include = [ '**/*.sass', '**/*.scss' ],
+    exclude = 'node_modules/**',
+  } = options;
+  const filter = createFilter(include, exclude);
   const insertFnName = '___$insertStyle';
   const styles = [];
   const styleMaps = {};


### PR DESCRIPTION
I had scss in node_modules that I wanted to process, so I tried setting exclude to `''`, but that's falsey, so it defaulted back to `'node_modules/**'`. This PR fixes it.