### PR TITLE
Add all imported SASS files to the "watch" list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,10 +174,16 @@ export = function plugin(options = {} as RollupPluginSassOptions): RollupPlugin 
         .then(res => processRenderResponse(pluginOptions, filePath, pluginState, res.css.toString().trim())
           .then(result => [res, result])
         )
-        .then(([res, codeResult]) => ({
-          code: codeResult,
-          map: {mappings: res.map ? res.map.toString() : ''},
-        })); // @note do not `catch` here - let error propagate to rollup level.
+        .then(([res, codeResult]) => {
+
+            res.stats.includedFiles.forEach(i => {this.addWatchFile(i)})
+
+            return {
+                code: codeResult,
+                map: {mappings: res.map ? res.map.toString() : ''}
+            }
+
+        }); // @note do not `catch` here - let error propagate to rollup level.
     },
 
     generateBundle(generateOptions: { file?: string },


### PR DESCRIPTION
One of the missing features for this plugin was that any files imported by the target file were not watched by Rollup, and so it wasn't particularly useful when running Rollup in  `--watch` mode.

This PR adds all of a files `includedFiles` returned after a render to the Rollup watch list `this.addWatchFile()`