### PR TITLE
issue-#101 - Updated 'Build and Test' gh-actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ sass({
 ## License
 
 [MIT](./LICENSE) &copy; 2022 [elycruz](https://github.com/elycruz), 
-@copy; 2016 [BinRui.Guan](mailto:differui@gmail.com)
+&copy; 2016 [BinRui.Guan](mailto:differui@gmail.com)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-rollup-plugin-sass [![build](https://github.com/elycruz/rollup-plugin-sass/actions/workflows/dev-build-and-test.yml/badge.svg)](https://github.com/elycruz/rollup-plugin-sass/actions/workflows/dev-build-and-test.yml)[![CircleCI](https://img.shields.io/circleci/project/github/differui/rollup-plugin-sass/master.svg?style=flat-square)](https://circleci.com/gh/differui/rollup-plugin-sass) [![issues](https://img.shields.io/github/issues/differui/rollup-plugin-sass.svg?style=flat-square)](https://www.npmjs.com/package/rollup-plugin-sass) [![npm](https://img.shields.io/npm/v/rollup-plugin-sass.svg?style=flat-square)](https://www.npmjs.com/package/rollup-plugin-sass) [![mit](https://img.shields.io/npm/l/rollup-plugin-sass.svg?style=flat-square)](https://opensource.org/licenses/MIT) [![Coverage Status](https://coveralls.io/repos/github/differui/rollup-plugin-sass/badge.svg?branch=master)](https://coveralls.io/github/differui/rollup-plugin-sass?branch=master)
+rollup-plugin-sass [![Build and Test](https://github.com/elycruz/rollup-plugin-sass/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/elycruz/rollup-plugin-sass/actions/workflows/build-and-test.yml)[![CircleCI](https://img.shields.io/circleci/project/github/differui/rollup-plugin-sass/master.svg?style=flat-square)](https://circleci.com/gh/differui/rollup-plugin-sass) [![issues](https://img.shields.io/github/issues/differui/rollup-plugin-sass.svg?style=flat-square)](https://www.npmjs.com/package/rollup-plugin-sass) [![npm](https://img.shields.io/npm/v/rollup-plugin-sass.svg?style=flat-square)](https://www.npmjs.com/package/rollup-plugin-sass) [![mit](https://img.shields.io/npm/l/rollup-plugin-sass.svg?style=flat-square)](https://opensource.org/licenses/MIT) [![Coverage Status](https://coveralls.io/repos/github/differui/rollup-plugin-sass/badge.svg?branch=master)](https://coveralls.io/github/differui/rollup-plugin-sass?branch=master)
 =====
 
 ## Installation
@@ -161,4 +161,5 @@ sass({
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENSE) &copy; 2022 [elycruz](https://github.com/elycruz), 
+@copy; 2016 [BinRui.Guan](mailto:differui@gmail.com)


### PR DESCRIPTION
 - 'Build and Test' badge now points to new 'gh-actions' build-and-test action.
 - Re-added attributions, in LICENSE section - These don't really need
to be removed right now and can remain listed in this section.