### PR TITLE
maintenance: (node fs module) deprecation warnings removal and annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-sass",
-  "version": "1.12.17",
+  "version": "1.12.18",
   "description": "Rollup Sass files.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/scripts/clean-and-run-downlevel-dts.js
+++ b/scripts/clean-and-run-downlevel-dts.js
@@ -17,7 +17,11 @@ const fs = require('fs').promises,
 
 // Run 'clean-and-run' process
 (async () =>
-    fs.rmdir(outputDir, {recursive: true})
+
+  // @note Conditional check here since we have a relaxed 'package.json.engines.node' value,
+  //   and `fs.rmdir` is being deprecated in later versions of node (node v18+).
+  // ----
+  (fs.rm ? fs.rm : fs.rmdir)(outputDir, {recursive: true})
 
       .then(() => fs.mkdir(outputDir))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,11 +34,14 @@ const MATCH_SASS_FILENAME_RE = /\.sass$/,
     let lastResult = Promise.resolve();
 
     /**
-     * Legacy Sass (*.scss/*.sass) file importer (works in new, and older, versions of `sass` module).
+     * Legacy Sass (*.scss/*.sass) file importer (works in new (< v2.0), and older, versions of `sass` (dart-sass) module).
+     *
      * @see https://sass-lang.com/documentation/js-api/modules#LegacyAsyncImporter
-     * @param {string} url - Url found in `@import`/`@use`, found in parent sass file, exactly as it appears in sass file.
-     * @param {string} prevUrl - Url of file that contains '@import' rule for `url`.
-     * @param {(result: LegacyImporterResult | SassImporterResult) => void} done - Signals import completion.  Note: `LegacyImporterResult`, and `SassImporterResult`, are the same here - We've defined the type for out plugin, since older versions of sass don't have the type defined amongst their types.
+     *
+     * @param {string} url - Url found in `@import`/`@use`, found in parent sass file;  E.g., exactly as it appears in sass file.
+     * @param {string} prevUrl - Url of file that contains '@import' rule for incoming file (`url`).
+     * @param {(result: LegacyImporterResult | SassImporterResult) => void} done - Signals import completion.  Note: `LegacyImporterResult`, and `SassImporterResult`, are the same here - We've defined the type for our plugin, since older versions of sass don't have this type defined.
+     * @note This importer may not work in dart-sass v2.0+ (which may be far off in the future, but is important to note: https://sass-lang.com/documentation/js-api/#legacy-api).
      * @returns {void}
      */
     const importer1 = (url: string, prevUrl: string, done: (rslt: SassImporterResult) => void): void => {
@@ -68,8 +71,9 @@ const MATCH_SASS_FILENAME_RE = /\.sass$/,
           file: url,
         }));
       }
-    }
-    return [importer1].concat(sassOptions.importer || [])
+    };
+
+    return [importer1].concat(sassOptions.importer || []);
   },
 
   processRenderResponse = (rollupOptions, file, state, inCss) => {


### PR DESCRIPTION
## Description

- Removed deprecation warning due to node v18+ deprecating 'fs.rmdir', in '*downlevel-dts', and 'index.test'.
- Removed the removal of the tmp write file (used in tests) from the 'test.after(...)' - We remove and start a new version of the dir., each time tests run, so no need to remove the dir. afterward.
- Corrected a test name, and annotated an '@ts-ignore'.
- Updated package version.