### PR TITLE
fix: rollup, and @rollup/pluginutils, version ranges update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,18 +22,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-  build-test-publish-to-github-pkgs:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,22 @@
 {
   "name": "rollup-plugin-sass",
-  "version": "1.12.17",
+  "version": "1.12.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-plugin-sass",
-      "version": "1.12.17",
+      "version": "1.12.18",
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
+        "@rollup/pluginutils": "^3 || ^4 || ^5",
         "resolve": "^1.5.0",
         "sass": "^1.7.2"
       },
       "devDependencies": {
         "@ava/typescript": "^3.0.1",
-        "@types/node": "^15.14.9",
+        "@types/node": "^18.14.6",
         "@types/resolve": "^0.0.8",
-        "@types/rollup": "^0.54.0",
-        "@types/sass": "^1.16.1",
         "ava": "^4.3.1",
         "coveralls": "^3.1.1",
         "downlevel-dts": "^0.10.0",
@@ -27,7 +25,7 @@
         "jsdom": "^17.0.0",
         "nyc": "^15.1.0",
         "postcss": "^8.4.16",
-        "rollup": "^1.32.1",
+        "rollup": "^1 || ^2 || ^3",
         "sinon": "^7.2.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
@@ -752,33 +750,14 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/rollup": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@types/rollup/-/rollup-0.54.0.tgz",
-      "integrity": "sha512-oeYztLHhQ98jnr+u2cs1c3tHOGtpzrm9DJlIdEjznwoXWidUbrI+X6ib7zCkPIbB7eJ7VbbKNQ5n/bPnSg6Naw==",
-      "deprecated": "This is a stub types definition for rollup (https://github.com/rollup/rollup). rollup provides its own type definitions, so you don't need @types/rollup installed!",
-      "dev": true,
-      "dependencies": {
-        "rollup": "*"
-      }
-    },
-    "node_modules/@types/sass": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.0.tgz",
-      "integrity": "sha512-DPSXNJ1rYLo88GyF9tuB4bsYGfpKI1a4+wOQmc+LI1SUoocm9QLRSpz0GxxuyjmJsYFIQo/dDlRSSpIXngff+w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -6473,32 +6452,14 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/rollup": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@types/rollup/-/rollup-0.54.0.tgz",
-      "integrity": "sha512-oeYztLHhQ98jnr+u2cs1c3tHOGtpzrm9DJlIdEjznwoXWidUbrI+X6ib7zCkPIbB7eJ7VbbKNQ5n/bPnSg6Naw==",
-      "dev": true,
-      "requires": {
-        "rollup": "*"
-      }
-    },
-    "@types/sass": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.0.tgz",
-      "integrity": "sha512-DPSXNJ1rYLo88GyF9tuB4bsYGfpKI1a4+wOQmc+LI1SUoocm9QLRSpz0GxxuyjmJsYFIQo/dDlRSSpIXngff+w==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-sass",
-  "version": "1.12.18",
+  "version": "1.12.19",
   "description": "Rollup Sass files.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -56,16 +56,14 @@
     ]
   },
   "dependencies": {
-    "@rollup/pluginutils": "^3.1.0",
+    "@rollup/pluginutils": "^3 || ^4 || ^5",
     "resolve": "^1.5.0",
     "sass": "^1.7.2"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
-    "@types/node": "^15.14.9",
+    "@types/node": "^18.14.6",
     "@types/resolve": "^0.0.8",
-    "@types/rollup": "^0.54.0",
-    "@types/sass": "^1.16.1",
     "ava": "^4.3.1",
     "coveralls": "^3.1.1",
     "downlevel-dts": "^0.10.0",
@@ -74,7 +72,7 @@
     "jsdom": "^17.0.0",
     "nyc": "^15.1.0",
     "postcss": "^8.4.16",
-    "rollup": "^1.32.1",
+    "rollup": "^1 || ^2 || ^3",
     "sinon": "^7.2.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"


### PR DESCRIPTION
Fixes #112 .

## Changes

- Updated 'rollup', and '@rollup/pluginutils', version ranges to allow an matching version of '@rollup/pluginutils' to be installed alongside 'rollup' v3.
- Removed '@types/rollup', and '@types/sass', from dev-deps due to these not being used in development, since they're just 'stub' packages (their implementation packages export/contain their own typings), and are deprecated, they are safe to removed.
- scripts - Updated 'clean-and-run-downlevel-dts' script, to ignore 'directory not found' warning, when attempting to delete the './ts*' directory, before genating it's new content, since removing the directory, before content generation, is what we're trying to do there.
- gh-actions - Removed unrequired 'github packages' action - We're only publishing to 'npm' for now.