### PR TITLE
test(insertStyle): ensures that tests are run in sequence

### DIFF
--- a/test/insertStyle.test.ts
+++ b/test/insertStyle.test.ts
@@ -5,7 +5,7 @@ import Sinon from 'sinon';
 
 const expectA = 'body{color:red}';
 
-test('should insertStyle works', async (t) => {
+test.serial('insertStyle should work in a DOM environment', async (t) => {
   const browser = new Browser();
   const page = browser.newPage();
 
@@ -20,14 +20,28 @@ test('should insertStyle works', async (t) => {
 
   // ---
   // Remove overrides
-  t.teardown(() => {
+  t.teardown(async () => {
     Sinon.restore();
+
+    await browser.close();
   });
 
   // -----
   // Execute the actual test
 
+  t.is(
+    Array.from(document.styleSheets).length,
+    0,
+    'Should not have stylesheets',
+  );
+
   const cssStr = insertStyle(expectA);
+
+  t.is(
+    Array.from(document.styleSheets).length,
+    1,
+    'Should include only `insertStyle` related stylesheet',
+  );
 
   const styleSheet = document.head.querySelector('style')!;
   t.is(
@@ -40,10 +54,8 @@ test('should insertStyle works', async (t) => {
     'text/css',
     'Should contain `type` attrib. equal to "text/css"',
   );
-
-  await browser.close();
 });
 
-test("insertStyle shouldn't choke when window is undefined", (t) => {
-  t.notThrows(() => insertStyle('css'));
+test.serial("insertStyle shouldn't choke when window is undefined", (t) => {
+  t.notThrows(() => insertStyle(expectA));
 });


### PR DESCRIPTION
Followup of https://github.com/elycruz/rollup-plugin-sass/pull/162#issuecomment-2397017512

> coverage went down for insertStyle function - maybe you can add coverage for it in your next PR (it appears the early return statement isn't covered (https://coveralls.io/builds/70199789)).

I made all `insertStyle` tests run in sequence. 
They need to be executed this way to ensure that the `global` scope is properly cleared after the test in the DOM environment. 
I also added 2 assertions to be sure that only one `<style />` is present inside the DOM during the test.

This should bring back `insertStyle` coverage to his original value.