### PR TITLE
Fix the compatibility issue of import statements on Windows.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ const processRenderResponse = (
            * *.css into *.html `head`.
            * @see insertStyle.ts for additional information
            */
-          imports = `import ${insertFnName} from '${__dirname}/insertStyle.js';\n`;
+          imports = `import ${insertFnName} from '${__dirname.replace(/\\/g, '/')}/insertStyle.js';\n`;
           defaultExport = `${insertFnName}(${out});`;
         } else if (!rollupOptions.output) {
           defaultExport = out;


### PR DESCRIPTION
issue

![image](https://github.com/user-attachments/assets/78fa7d0e-9f50-40a6-af80-540b6765b08a)

the correct path should be 'D:\repos\vapd-extensions\node_modules\rollup-plugin-sass\dist/insertStyle.js'

but I got

```
epos
apd-extensions
ollup-plugin-sassdist/insertStyle.js
```

This PR also fixes the error reported by the "Should insert CSS into head tag" unit test on Windows.

before

![image](https://github.com/user-attachments/assets/7f596396-a902-4f09-b83a-0df5d82ecb72)

after

![image](https://github.com/user-attachments/assets/e359240b-8fc3-4670-9467-54629158ce8f)

