### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@
 # and https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry .
 
 name: Publish
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/elycruz/rollup-plugin-sass/security/code-scanning/4](https://github.com/elycruz/rollup-plugin-sass/security/code-scanning/4)

The fix is to add a `permissions` block to the workflow, specifying only the privileges required for the workflow's completion. Usually, for a publish job, `contents: read` is a safe baseline. If the workflow modifies pull requests, issues, or releases, these can be expanded granularly. In this case, since the workflow publishes to npm (external registry) and does not indicate the need for repository write actions, adding `permissions: contents: read` at the root of the workflow is sufficient and follows best practices. This change should be made at the top level of `.github/workflows/publish.yml`, anywhere above the `jobs` key (ideally right after `name:` and before `on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
