### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,8 @@ jobs:
           file: 'coverage/tests.lcov'
 
   code-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/elycruz/rollup-plugin-sass/security/code-scanning/3](https://github.com/elycruz/rollup-plugin-sass/security/code-scanning/3)

The best way to fix this issue is to add an explicit `permissions` block to the `code-check` job in `.github/workflows/CI.yml`. Since the job only checks out the repo and runs formatting/linting, it requires only read access to repository contents. Therefore, setting `permissions: contents: read` at the job level is sufficient and follows the principle of least privilege.

Specifically, add the following under the `code-check:` job, before `runs-on: ubuntu-latest` (line 43):

```yaml
permissions:
  contents: read
```

No new methods, imports, or dependencies are required; just the addition of the YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
