### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build-and-test:
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/elycruz/rollup-plugin-sass/security/code-scanning/2](https://github.com/elycruz/rollup-plugin-sass/security/code-scanning/2)

To fix this issue, add an explicit `permissions` block to the `build-and-test` job in `.github/workflows/CI.yml`. As a minimal starting point, use `permissions: contents: read`, which allows jobs to read repository contents but not write. This is typically enough for jobs that only need to perform actions like cloning the repo, installing dependencies, building code, and reporting coverage, unless a step requires write access (none are apparent here). Insert the following YAML directly below the job name (usually after line 22), but before other keys such as `strategy` or `runs-on`, for clarity and correct processing order.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
