### PR TITLE
perf: #219 async resolve in sass importers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@eslint/js": "^9.17.0",
         "@types/icss-utils": "^5.1.2",
         "@types/node": "^18.14.6",
-        "@types/resolve": "^0.0.8",
+        "@types/resolve": "^1.20.0",
         "@types/sinon": "^17.0.3",
         "ava": "^6.1.3",
         "coveralls-next": "^4.2.1",
@@ -1584,14 +1584,11 @@
       }
     },
     "node_modules/@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/sinon": {
       "version": "17.0.4",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@eslint/js": "^9.17.0",
     "@types/icss-utils": "^5.1.2",
     "@types/node": "^18.14.6",
-    "@types/resolve": "^0.0.8",
+    "@types/resolve": "^1.20.0",
     "@types/sinon": "^17.0.3",
     "ava": "^6.1.3",
     "coveralls-next": "^4.2.1",

--- a/src/utils/getImporterList.ts
+++ b/src/utils/getImporterList.ts
@@ -6,6 +6,17 @@ import resolve from 'resolve';
 import { warn } from './logger';
 import { fileURLToPath, pathToFileURL } from 'url';
 
+const resolveAsync = (id: string, opts: resolve.AsyncOpts): Promise<string> =>
+  new Promise((res, rej) =>
+    resolve(id, opts, (err, resolved) => {
+      if (err) {
+        rej(err);
+      } else {
+        res(resolved as string);
+      }
+    }),
+  );
+
 const MATCH_NODE_MODULE_RE = /^~([a-z0-9]|@).+/i;
 
 /**
@@ -39,25 +50,19 @@ export const getImporterListLegacy = (
       extensions: ['.scss', '.sass'],
     };
 
-    // @todo This block should run as a promise instead, will help ensure we're not blocking the thread it is
-    //   running on, even though `sass` is probably already running the importer in one.
-    try {
-      const file = resolve.sync(moduleUrl, resolveOptions);
-      lastResult = lastResult.then(() => done({ file }));
-    } catch (err) {
-      warn('[rollup-plugin-sass]: Recovered from error: ', err);
-      // If importer has sibling importers then exit and allow one of the other
-      //  importers to attempt file path resolution.
-      if (Array.isArray(importOption) && importOption.length > 1) {
-        lastResult = lastResult.then(() => done(null));
-        return;
-      }
-      lastResult = lastResult.then(() =>
-        done({
-          file: url,
-        }),
-      );
-    }
+    lastResult = lastResult
+      .then(() => resolveAsync(moduleUrl, resolveOptions))
+      .then((file) => done({ file }))
+      .catch((err) => {
+        warn('[rollup-plugin-sass]: Recovered from error: ', err);
+        // If importer has sibling importers then exit and allow one of the other
+        //  importers to attempt file path resolution.
+        if (Array.isArray(importOption) && importOption.length > 1) {
+          done(null);
+        } else {
+          done({ file: url });
+        }
+      });
   };
 
   return [importer1].concat((importOption as never) || []);
@@ -71,7 +76,7 @@ export const getImporterListModern = (
   importOption: Options<'async'>['importers'],
 ) => {
   const importer: FileImporter<'async'> = {
-    findFileUrl(url, context) {
+    async findFileUrl(url, context) {
       if (!MATCH_NODE_MODULE_RE.test(url)) {
         return null;
       }
@@ -84,7 +89,7 @@ export const getImporterListModern = (
       };
 
       try {
-        const file = resolve.sync(moduleUrl, resolveOptions);
+        const file = await resolveAsync(moduleUrl, resolveOptions);
         return pathToFileURL(file);
       } catch (err) {
         warn('[rollup-plugin-sass]: error resolving import path: ', err);

--- a/test/getImporterList.test.ts
+++ b/test/getImporterList.test.ts
@@ -1,0 +1,49 @@
+import test from 'ava';
+import { pathToFileURL } from 'url';
+import type { FileImporter, LegacyImporter } from 'sass';
+
+import {
+  getImporterListLegacy,
+  getImporterListModern,
+} from '../src/utils/getImporterList';
+
+const MISSING_MODULE = '~no-such-module-zzz-coverage-fixture/x';
+
+type LegacyDoneResult = { file: string } | null;
+type LegacyImporterCallable = (
+  url: string,
+  prev: string,
+  done: (result: LegacyDoneResult) => void,
+) => void;
+
+const asCallable = (importer: LegacyImporter<'async'>): LegacyImporterCallable =>
+  importer as unknown as LegacyImporterCallable;
+
+test('legacy importer1: resolve failure with no siblings falls back to original url', async (t) => {
+  const importers = getImporterListLegacy(undefined);
+  const importer1 = asCallable(importers[0]);
+  const result = await new Promise<LegacyDoneResult>((resolve) => {
+    importer1(MISSING_MODULE, __filename, resolve);
+  });
+  t.deepEqual(result, { file: MISSING_MODULE });
+});
+
+test('legacy importer1: resolve failure with sibling importers returns null', async (t) => {
+  const noopImporter: LegacyImporter<'async'> = (_url, _prev, done) =>
+    done(null);
+  const importers = getImporterListLegacy([noopImporter, noopImporter]);
+  const importer1 = asCallable(importers[0]);
+  const result = await new Promise<LegacyDoneResult>((resolve) => {
+    importer1(MISSING_MODULE, __filename, resolve);
+  });
+  t.is(result, null);
+});
+
+test('modern findFileUrl: resolve failure returns null', async (t) => {
+  const importers = getImporterListModern(undefined);
+  const modern = importers[0] as FileImporter<'async'>;
+  const result = await modern.findFileUrl(MISSING_MODULE, {
+    containingUrl: pathToFileURL(__filename),
+  } as never);
+  t.is(result, null);
+});

--- a/test/getImporterList.test.ts
+++ b/test/getImporterList.test.ts
@@ -16,8 +16,9 @@ type LegacyImporterCallable = (
   done: (result: LegacyDoneResult) => void,
 ) => void;
 
-const asCallable = (importer: LegacyImporter<'async'>): LegacyImporterCallable =>
-  importer as unknown as LegacyImporterCallable;
+const asCallable = (
+  importer: LegacyImporter<'async'>,
+): LegacyImporterCallable => importer as unknown as LegacyImporterCallable;
 
 test('legacy importer1: resolve failure with no siblings falls back to original url', async (t) => {
   const importers = getImporterListLegacy(undefined);


### PR DESCRIPTION
## Summary
- Bumps \`@types/resolve\` from \`^0.0.8\` to \`^1.20.x\` (devDep only).
- Converts both legacy \`importer1\` and modern \`findFileUrl\` to use async \`resolve\`.
- Preserves serial ordering via the existing \`lastResult\` Promise chain (legacy) and via sass's built-in async-importer contract (modern).

Closes #219.

## SemVer impact
PATCH — internal refactor; identical sass-importer contract.

## Validation
- \`npm run format:fix && npm run lint && npm run build && npm test\` — all green locally.
- Existing \`should resolve ~ as node_modules\` tests pass for both apis.