### PR TITLE
feat: #220 emit CSS to outputOptions.dir when output: true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ import { createFilter } from '@rollup/pluginutils';
  *          so no actual symbols should be imported.
  *          Interfaces and non-concrete types are ok.
  */
-import type { Plugin as RollupPlugin, TransformResult } from 'rollup';
+import type {
+  OutputBundle,
+  Plugin as RollupPlugin,
+  TransformResult,
+} from 'rollup';
 
 import type { RollupPluginSassOptions, RollupPluginSassState } from './types';
 import {
@@ -178,7 +182,7 @@ export = function plugin(
       }
     },
 
-    async generateBundle(outputOptions, _, isWrite) {
+    async generateBundle(outputOptions, bundle: OutputBundle, isWrite) {
       const { styles } = pluginState;
       const { output, insert } = pluginOptions;
 
@@ -208,6 +212,18 @@ export = function plugin(
         }
         dest = `${dest}.css`;
 
+        await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+        await fs.promises.writeFile(dest, css);
+        return;
+      }
+
+      if (!insert && outputOptions.dir && output === true) {
+        const entry = Object.values(bundle).find(
+          (item) => item.type === 'chunk' && item.isEntry,
+        );
+        if (!entry) return;
+        const baseName = path.parse(entry.fileName).name;
+        const dest = path.join(outputOptions.dir, `${baseName}.css`);
         await fs.promises.mkdir(path.dirname(dest), { recursive: true });
         await fs.promises.writeFile(dest, css);
         return;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -560,6 +560,48 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
     test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_LEGACY);
     test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_MODERN);
   }
+
+  {
+    const title =
+      'should support output as true with outputOptions.dir (code-splitting / dir-based output)';
+
+    const macro = test.macro<[RollupPluginSassOptions]>({
+      async exec(t, pluginOptions) {
+        const outputDir = path.join(
+          getTestOutputDir(pluginOptions.api),
+          'support-output-as-true-with-dir',
+        );
+
+        const outputBundle = await rollup({
+          input: 'test/fixtures/output-true/index.js',
+          plugins: [sass({ ...pluginOptions, output: true })],
+          onwarn,
+        });
+
+        await outputBundle.write({
+          format: 'es',
+          dir: outputDir,
+        });
+
+        // The CSS file should be written as <entry-stem>.css inside outputDir.
+        // The entry chunk file name is derived from the input file name → "index.css".
+        const outputStylePath = path.join(outputDir, 'index.css');
+        const outputStyleContent = await fs.readFile(outputStylePath);
+        t.true(
+          stripNewLines(outputStyleContent.toString()).includes(expectA),
+          `CSS file should include expectA content`,
+        );
+        t.true(
+          stripNewLines(outputStyleContent.toString()).includes(expectB),
+          `CSS file should include expectB content`,
+        );
+      },
+      title: createApiOptionTestCaseTitle,
+    });
+
+    test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_LEGACY);
+    test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_MODERN);
+  }
 }
 // #endregion
 


### PR DESCRIPTION
## Summary
- New `generateBundle` branch for the previously-unhandled `outputOptions.dir` case.
- Adds a regression test.

Closes #220.

## SemVer impact
MINOR — purely additive (this configuration previously emitted nothing).

## Validation
- `npm run format:fix && npm run lint && npm run build && npm test` — all green locally.