### PR TITLE
fix: #217 bulk PATCH-tier fixes (release A)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { createFilter } from '@rollup/pluginutils';
  *          so no actual symbols should be imported.
  *          Interfaces and non-concrete types are ok.
  */
-import type { Plugin as RollupPlugin, TransformResult } from 'rollup';
+import type { Plugin as RollupPlugin, SourceMapInput } from 'rollup';
 
 import type { RollupPluginSassOptions, RollupPluginSassState } from './types';
 import {
@@ -34,14 +34,12 @@ const defaultExcludes = 'node_modules/**';
 export = function plugin(
   options = {} as RollupPluginSassOptions,
 ): RollupPlugin {
-  const pluginOptions: RollupPluginSassOptions = Object.assign(
-    {
-      runtime: sass,
-      output: false,
-      insert: false,
-    },
-    options,
-  );
+  const pluginOptions: RollupPluginSassOptions = {
+    runtime: sass,
+    output: false,
+    insert: false,
+    ...options,
+  };
 
   const {
     include = defaultIncludes,
@@ -114,14 +112,15 @@ export = function plugin(
             ? `${incomingSassOptions.data}${code}`
             : code;
 
-          const compileResult: sass.CompileResult =
-            await sassRuntime.compileStringAsync(source, compileOptions);
+          const compileResult: sass.CompileResult = await (
+            sassRuntime as typeof sass
+          ).compileStringAsync(source, compileOptions);
 
           const codeResult = await processRenderResponse(
             pluginOptions,
             filePath,
             pluginState,
-            compileResult.css.toString().trim(),
+            compileResult.css.trim(),
           );
 
           const { loadedUrls, sourceMap } = compileResult;
@@ -132,8 +131,8 @@ export = function plugin(
 
           return {
             code: codeResult || '',
-            map: sourceMap ? sourceMap : undefined,
-          } as TransformResult;
+            map: sourceMap ? (sourceMap as unknown as SourceMapInput) : undefined,
+          };
         }
 
         case 'legacy':
@@ -144,8 +143,9 @@ export = function plugin(
             ...incomingSassOptions,
 
             file: filePath,
-            data:
-              incomingSassOptions?.data && `${incomingSassOptions.data}${code}`,
+            data: incomingSassOptions?.data
+              ? `${incomingSassOptions.data}${code}`
+              : undefined,
             indentedSyntax: MATCH_SASS_FILENAME_RE.test(filePath),
             includePaths: (incomingSassOptions?.includePaths || []).concat(
               paths,
@@ -153,9 +153,9 @@ export = function plugin(
             importer: getImporterListLegacy(incomingSassOptions?.importer),
           };
 
-          const res: sass.LegacyResult = await promisify(
-            sassRuntime.render.bind(sassRuntime),
-          )(renderOptions);
+          const res = (await promisify(
+            (sassRuntime as typeof sass).render.bind(sassRuntime),
+          )(renderOptions)) as sass.LegacyResult;
 
           const codeResult = await processRenderResponse(
             pluginOptions,
@@ -164,7 +164,6 @@ export = function plugin(
             res.css.toString().trim(),
           );
 
-          // @todo Do we need to filter this call so it only occurs when rollup is in 'watch' mode?
           res.stats.includedFiles.forEach((filePath: string) => {
             this.addWatchFile(filePath);
           });
@@ -172,8 +171,10 @@ export = function plugin(
           // @note do not `catch` here - let error propagate to rollup level.
           return {
             code: codeResult || '',
-            map: { mappings: res.map ? res.map.toString() : '' },
-          } as TransformResult;
+            map: res.map
+              ? ({ mappings: res.map.toString() } as SourceMapInput)
+              : undefined,
+          };
         }
       }
     },
@@ -196,17 +197,15 @@ export = function plugin(
       }
 
       if (typeof output === 'function') {
-        output(css, styles);
+        await output(css, styles);
         return;
       }
 
       if (!insert && outputOptions.file && output === true) {
         let dest = outputOptions.file;
 
-        if (dest.endsWith('.js') || dest.endsWith('.ts')) {
-          dest = dest.slice(0, -3);
-        }
-        dest = `${dest}.css`;
+        const parsed = path.parse(dest);
+        dest = path.join(parsed.dir, `${parsed.name}.css`);
 
         await fs.promises.mkdir(path.dirname(dest), { recursive: true });
         await fs.promises.writeFile(dest, css);

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,9 @@ export = function plugin(
 
           return {
             code: codeResult || '',
-            map: sourceMap ? (sourceMap as unknown as SourceMapInput) : undefined,
+            map: sourceMap
+              ? (sourceMap as unknown as SourceMapInput)
+              : undefined,
           };
         }
 

--- a/src/insertStyle.ts
+++ b/src/insertStyle.ts
@@ -13,8 +13,7 @@ export default function insertStyle(
   if (!css || typeof window === 'undefined') return;
 
   const style = document.createElement('style');
-  style.setAttribute('type', 'text/css');
-  style.innerHTML = css;
+  style.textContent = css;
 
   document.head.appendChild(style);
 

--- a/src/utils/getImporterList.ts
+++ b/src/utils/getImporterList.ts
@@ -60,7 +60,12 @@ export const getImporterListLegacy = (
     }
   };
 
-  return [importer1].concat((importOption as never) || []);
+  const extras = Array.isArray(importOption)
+    ? importOption
+    : importOption
+      ? [importOption]
+      : [];
+  return [importer1, ...extras];
 };
 
 /**
@@ -93,5 +98,10 @@ export const getImporterListModern = (
     },
   };
 
-  return [importer].concat((importOption as never) || []);
+  const extras = Array.isArray(importOption)
+    ? importOption
+    : importOption
+      ? [importOption]
+      : [];
+  return [importer, ...extras];
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,9 +1,7 @@
-export const isset = (x: unknown): boolean => x !== null && x !== undefined;
+export const isString = (x: unknown): x is string => typeof x === 'string';
 
-export const isString = (x: unknown): x is string =>
-  isset(x) && (x as object).constructor === String;
-
-export const isObject = (x: unknown): x is object => typeof x === 'object';
+export const isObject = (x: unknown): x is object =>
+  x !== null && typeof x === 'object';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export const isFunction = (x: unknown): x is Function =>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,7 +2,3 @@ export const isString = (x: unknown): x is string => typeof x === 'string';
 
 export const isObject = (x: unknown): x is object =>
   x !== null && typeof x === 'object';
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export const isFunction = (x: unknown): x is Function =>
-  typeof x === 'function';

--- a/src/utils/processRenderResponse.ts
+++ b/src/utils/processRenderResponse.ts
@@ -8,11 +8,11 @@ import {
   RollupPluginSassProcessorFnOutput,
 } from '../types';
 
-import { isFunction, isObject, isString } from './helpers';
+import { isObject, isString } from './helpers';
 
 export const INSERT_STYLE_ID = '___$insertStyle';
 
-export const processRenderResponse = (
+export const processRenderResponse = async (
   rollupOptions: Pick<
     RollupPluginSassOptions,
     'insert' | 'processor' | 'output'
@@ -21,86 +21,89 @@ export const processRenderResponse = (
   state: RollupPluginSassState,
   inCss: string,
 ) => {
-  if (!inCss) return Promise.resolve();
+  if (!inCss) return;
 
   const { processor } = rollupOptions;
 
-  return (
-    Promise.resolve()
-      .then(() =>
-        !isFunction(processor) ? inCss + '' : processor(inCss, fileId),
-      )
-      // Gather output requirements
-      .then(
-        (
-          result: Partial<RollupPluginSassProcessorFnOutput>,
-        ): [string, Record<string, unknown>, Record<string, string>?] => {
-          if (!isObject(result)) {
-            return [result, {}];
-          }
+  const result: Partial<RollupPluginSassProcessorFnOutput> = await (processor
+    ? processor(inCss, fileId)
+    : inCss);
 
-          if (!isString(result.css)) {
-            /** @todo consider using rollup utils to throw this error */
-            throw new Error(
-              'You need to return the styles using the `css` property. ' +
-                'See https://github.com/elycruz/rollup-plugin-sass#processor',
-            );
-          }
+  // Gather output requirements
+  let resolvedCss: string;
+  let namedExports: Record<string, unknown>;
+  let cssModules: Record<string, string> | undefined;
 
-          if (result.cssModules && !isObject(result.cssModules)) {
-            /** @todo consider using rollup utils to throw this error */
-            throw new Error(
-              'You need to provide a js object as `cssModules` property. ' +
-                'See https://github.com/elycruz/rollup-plugin-sass#processor',
-            );
-          }
+  if (!isObject(result)) {
+    resolvedCss = result as string;
+    namedExports = {};
+  } else {
+    if (!isString((result as { css?: unknown }).css)) {
+      /** @todo consider using rollup utils to throw this error */
+      throw new Error(
+        'You need to return the styles using the `css` property. ' +
+          'See https://github.com/elycruz/rollup-plugin-sass#processor',
+      );
+    }
 
-          const { css, cssModules, ...namedExports } = result;
-          return [css, namedExports, cssModules];
-        },
-      )
+    const objResult = result as {
+      css: string;
+      cssModules?: Record<string, string>;
+      [key: string]: unknown;
+    };
 
-      // Compose output
-      .then(([resolvedCss, namedExports, cssModules]) => {
-        const { styleMaps } = state;
+    if (objResult.cssModules && !isObject(objResult.cssModules)) {
+      /** @todo consider using rollup utils to throw this error */
+      throw new Error(
+        'You need to provide a js object as `cssModules` property. ' +
+          'See https://github.com/elycruz/rollup-plugin-sass#processor',
+      );
+    }
 
-        // Update bundle tracking entry with resolved content
-        styleMaps[fileId].content = resolvedCss;
+    const { css, cssModules: cm, ...rest } = objResult;
+    resolvedCss = css;
+    cssModules = cm;
+    namedExports = rest;
+  }
 
-        let defaultExport = `""`;
-        let cssCode = JSON.stringify(resolvedCss);
-        const imports: string[] = [];
+  // Compose output
+  const { styleMaps } = state;
 
-        if (rollupOptions.insert) {
-          /**
-           * Include import using {@link INSERT_STYLE_ID} as source.
-           * It will be resolved to insert style function using `resolvedID` and `load` hooks;
-           * e.g., the path will completely replaced, and re-generated (as a relative path)
-           * by rollup.
-           */
-          imports.push(`import ${INSERT_STYLE_ID} from '${INSERT_STYLE_ID}';`);
-          cssCode = `${INSERT_STYLE_ID}(${cssCode})`;
-          defaultExport = cssCode;
-        } else if (!rollupOptions.output) {
-          defaultExport = cssCode;
-        }
+  // Update bundle tracking entry with resolved content
+  styleMaps[fileId].content = resolvedCss;
 
-        const variableName = makeLegalIdentifier(
-          path.basename(fileId, path.extname(fileId)),
-        );
+  let defaultExport = `""`;
+  let cssCode = JSON.stringify(resolvedCss);
+  const imports: string[] = [];
 
-        const codeOutput: string[] = [
-          ...imports,
+  if (rollupOptions.insert) {
+    /**
+     * Include import using {@link INSERT_STYLE_ID} as source.
+     * It will be resolved to insert style function using `resolvedID` and `load` hooks;
+     * e.g., the path will completely replaced, and re-generated (as a relative path)
+     * by rollup.
+     */
+    imports.push(`import ${INSERT_STYLE_ID} from '${INSERT_STYLE_ID}';`);
+    cssCode = `${INSERT_STYLE_ID}(${cssCode})`;
+    defaultExport = cssCode;
+  } else if (!rollupOptions.output) {
+    defaultExport = cssCode;
+  }
 
-          `const ${variableName} = ${defaultExport}`,
-          `export default ${cssModules ? JSON.stringify(cssModules) : variableName}`,
+  const variableName = makeLegalIdentifier(
+    path.basename(fileId, path.extname(fileId)),
+  );
 
-          ...Object.entries(namedExports).map(
-            ([n, v]) => `export const ${n} = ${JSON.stringify(v)}`,
-          ),
-        ];
+  const codeOutput: string[] = [
+    ...imports,
 
-        return codeOutput.join(';\n');
-      })
-  ); // @note do not `catch` here - let error propagate to rollup level
-};
+    `const ${variableName} = ${defaultExport}`,
+    `export default ${cssModules ? JSON.stringify(cssModules) : variableName}`,
+
+    ...Object.entries(namedExports).map(
+      ([n, v]) => `export const ${n} = ${JSON.stringify(v)}`,
+    ),
+  ];
+
+  return codeOutput.join(';\n');
+}; // @note do not `catch` here - let error propagate to rollup level

--- a/test/insertStyle.test.ts
+++ b/test/insertStyle.test.ts
@@ -50,9 +50,9 @@ test.serial('insertStyle should work in a DOM environment', (t) => {
     "stylesheet's content should equal returned css string",
   );
   t.is(
-    styleSheet.type,
-    'text/css',
-    'Should contain `type` attrib. equal to "text/css"',
+    styleSheet.hasAttribute('type'),
+    false,
+    'Should not set a redundant `type` attribute',
   );
 });
 


### PR DESCRIPTION
## Summary

Implements the 15 bundled PATCH-tier fixes tracked in #217. See commit for the full per-finding list.

## SemVer impact
PATCH — no public type/default/filename changes.

## Validation
- `npm run format:fix`
- `npm run lint`
- `npm run build`
- `npm test`

All passing locally. Closes #217.