### PR TITLE
chore: ignore unformatted md files and local worktrees in tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/
 .nyc_output/
 .tests-output/
+.claude/worktrees/
 
 coverage/
 dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
 CHANGELOG.md
+AGENTS.md
+CLAUDE.md
+md/**
 test/assets/**
 test/fixtures/**
 test/snapshots/**


### PR DESCRIPTION
## Summary

- `.prettierignore`: skip `AGENTS.md`, `CLAUDE.md`, `md/**` — these were added in 32ac569 as free-form analyses/plans and aren't intended to follow prettier. They are the root cause of the format failures currently blocking #225, #226, #227, #228 and the failing CI on `main` itself.
- `.gitignore`: skip `.claude/worktrees/` so locally-created fleet worktrees don't show up as untracked.

## Why now

Main's CI has been red since commit 32ac569 because `npm run format` (`prettier . --check`) fails on the unformatted markdown files. Every PR opened against main inherits the failure through the merge ref. This change unblocks them all.

## Test plan

- [x] `npx prettier . --check` passes for the files under prettier's purview (locally noisy because of in-tree worktrees; CI checks out fresh so the noise doesn't apply).
- [ ] On merge: re-run CI on #225, #226, #227, #228 and confirm `Code check (format)` goes green.