### PR TITLE
fix: reset sass state per build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,11 @@ export = function plugin(
       }
     },
 
+    buildStart() {
+      pluginState.styles = [];
+      pluginState.styleMaps = {};
+    },
+
     async transform(code, filePath) {
       if (!filter(filePath)) {
         return;

--- a/test/fixtures/watch-stale/keep.scss
+++ b/test/fixtures/watch-stale/keep.scss
@@ -1,0 +1,3 @@
+.keep-watch-stale {
+  color: green;
+}

--- a/test/fixtures/watch-stale/stale.scss
+++ b/test/fixtures/watch-stale/stale.scss
@@ -1,0 +1,3 @@
+.stale-watch-stale {
+  color: red;
+}

--- a/test/fixtures/watch-stale/with-stale.js
+++ b/test/fixtures/watch-stale/with-stale.js
@@ -1,0 +1,2 @@
+import './keep.scss';
+import './stale.scss';

--- a/test/fixtures/watch-stale/without-stale.js
+++ b/test/fixtures/watch-stale/without-stale.js
@@ -1,0 +1,1 @@
+import './keep.scss';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -560,6 +560,54 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
     test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_LEGACY);
     test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_MODERN);
   }
+
+  {
+    const title = 'should reset output CSS between sequential builds';
+
+    const macro = test.macro<[RollupPluginSassOptions]>({
+      async exec(t, pluginOptions) {
+        const outputCss: string[] = [];
+        const plugin = sass({
+          ...pluginOptions,
+          output: (css) => outputCss.push(css),
+        });
+
+        const firstBundle = await rollup({
+          input: 'test/fixtures/watch-stale/with-stale.js',
+          plugins: [plugin],
+          onwarn,
+        });
+        await firstBundle.write({
+          ...TEST_GENERATE_OPTIONS,
+          file: path.join(
+            getTestOutputDir(pluginOptions.api),
+            'watch-stale-with.js',
+          ),
+        });
+
+        const secondBundle = await rollup({
+          input: 'test/fixtures/watch-stale/without-stale.js',
+          plugins: [plugin],
+          onwarn,
+        });
+        await secondBundle.write({
+          ...TEST_GENERATE_OPTIONS,
+          file: path.join(
+            getTestOutputDir(pluginOptions.api),
+            'watch-stale-without.js',
+          ),
+        });
+
+        t.true(outputCss[0].includes('stale-watch-stale'));
+        t.true(outputCss[1].includes('keep-watch-stale'));
+        t.false(outputCss[1].includes('stale-watch-stale'));
+      },
+      title: createApiOptionTestCaseTitle,
+    });
+
+    test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_LEGACY);
+    test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_MODERN);
+  }
 }
 // #endregion
 


### PR DESCRIPTION
## Summary
- reset collected Sass output state in the Rollup buildStart hook
- add sequential-build coverage to ensure CSS from a previous graph does not leak into a later build
- include watch-stale fixtures for both legacy and modern Sass API test cases

Closes #218

## Verification
- npm run lint
- npm test