### PR TITLE
refactor(types): #224 type the public runtime option instead of any

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,11 +45,8 @@ export = function plugin(
     ...options,
   };
 
-  const {
-    include = defaultIncludes,
-    exclude = defaultExcludes,
-    runtime: sassRuntime,
-  } = pluginOptions;
+  const { include = defaultIncludes, exclude = defaultExcludes } =
+    pluginOptions;
 
   const filter = createFilter(include, exclude);
 
@@ -102,7 +99,8 @@ export = function plugin(
 
       switch (pluginOptions.api) {
         case 'modern': {
-          const { options: incomingSassOptions } = pluginOptions;
+          const { options: incomingSassOptions, runtime: sassRuntime = sass } =
+            pluginOptions;
 
           const compileOptions: sass.StringOptions<'async'> = {
             ...incomingSassOptions,
@@ -122,9 +120,8 @@ export = function plugin(
             ? `${incomingSassOptions.data}${code}`
             : code;
 
-          const compileResult: sass.CompileResult = await (
-            sassRuntime as typeof sass
-          ).compileStringAsync(source, compileOptions);
+          const compileResult: sass.CompileResult =
+            await sassRuntime.compileStringAsync(source, compileOptions);
 
           const codeResult = await processRenderResponse(
             pluginOptions,
@@ -149,7 +146,8 @@ export = function plugin(
 
         case 'legacy':
         default: {
-          const { options: incomingSassOptions } = pluginOptions;
+          const { options: incomingSassOptions, runtime: sassRuntime = sass } =
+            pluginOptions;
 
           const renderOptions: sass.LegacyOptions<'async'> = {
             ...incomingSassOptions,
@@ -166,7 +164,7 @@ export = function plugin(
           };
 
           const res = (await promisify(
-            (sassRuntime as typeof sass).render.bind(sassRuntime),
+            sassRuntime.render.bind(sassRuntime),
           )(renderOptions)) as sass.LegacyResult;
 
           const codeResult = await processRenderResponse(

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,21 @@ import type {
   Options as SassOptions,
 } from 'sass';
 
+/**
+ * Minimal shape required from a sass-compatible runtime when using the
+ * modern asynchronous API.  Anything exposing {@link import('sass').compileStringAsync}
+ * (e.g. the `sass` module itself, or a compatible shim) satisfies this contract.
+ */
+export type SassRuntimeModern = Pick<typeof import('sass'), 'compileStringAsync'>;
+
+/**
+ * Minimal shape required from a sass-compatible runtime when using the
+ * legacy asynchronous API.  Anything exposing {@link import('sass').render}
+ * (e.g. the `sass` module itself, `node-sass`, or a compatible shim) satisfies
+ * this contract.
+ */
+export type SassRuntimeLegacy = Pick<typeof import('sass'), 'render'>;
+
 interface StyleSheetIdAndContent {
   id?: string;
   content?: string;
@@ -60,12 +75,6 @@ interface RollupPluginSassSharedOptions {
    * ```
    */
   output?: boolean | string | RollupPluginSassOutputFn;
-
-  /**
-   * Sass runtime instance - sass, node-sass or other etc..
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  runtime?: any;
 }
 
 export type RollupPluginSassModernOptions = Omit<
@@ -86,10 +95,20 @@ export type RollupPluginSassOptions =
   | (RollupPluginSassSharedOptions & {
       api: 'modern';
       options?: RollupPluginSassModernOptions;
+      /**
+       * Sass runtime instance - sass, or a compatible shim, exposing
+       * {@link import('sass').compileStringAsync}.
+       */
+      runtime?: SassRuntimeModern;
     })
   | (RollupPluginSassSharedOptions & {
       api?: 'legacy';
       options?: RollupPluginSassLegacyOptions;
+      /**
+       * Sass runtime instance - sass, node-sass, or a compatible shim, exposing
+       * {@link import('sass').render}.
+       */
+      runtime?: SassRuntimeLegacy;
     });
 
 export type RollupPluginSassState = {


### PR DESCRIPTION
## Summary

Resolves #224. Removes `runtime?: any` from `RollupPluginSassSharedOptions` (along with the `@typescript-eslint/no-explicit-any` disable) and moves `runtime` into each discriminant of `RollupPluginSassOptions` with an api-specific shape.

- `api: 'modern'` -> `runtime?: SassRuntimeModern` (`Pick<typeof import('sass'), 'compileStringAsync'>`)
- `api: 'legacy'` (or undefined) -> `runtime?: SassRuntimeLegacy` (`Pick<typeof import('sass'), 'render'>`)

`src/index.ts` no longer needs the `as typeof sass` casts on the modern or legacy runtime calls; the discriminated union now narrows the runtime correctly at the use sites. The `runtime: sass` default still works because the sass module satisfies both runtime shapes.

## Breaking change / migration

TypeScript consumers passing custom runtimes will now be typechecked. If your runtime doesn't expose the api-specific method, it will fail to compile.

Migration:
- Modern: pass a value matching `{ compileStringAsync(...) }`.
- Legacy: pass a value matching `{ render(...) }` (e.g. `node-sass`).

## Test plan

- [x] `npm run lint:fix` clean
- [x] `npm run build` passes
- [x] `npm test` passes (57/57)
- [x] `npm run test:types` (`tsc --project tsconfig.spec.json --noEmit`) passes
- [x] Existing `should support options.runtime` test still passes for both apis

🤖 Generated with [Claude Code](https://claude.com/claude-code)