### PR TITLE
feat(modern-api)!: #221 drive sourceMap from explicit plugin option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export = function plugin(
       switch (pluginOptions.api) {
         case 'modern': {
           const { options: incomingSassOptions } = pluginOptions;
+          const wantsSourceMap = pluginOptions.sourceMap === true;
 
           const compileOptions: sass.StringOptions<'async'> = {
             ...incomingSassOptions,
@@ -110,8 +111,13 @@ export = function plugin(
             loadPaths: (incomingSassOptions?.loadPaths || []).concat(paths),
             importers: getImporterListModern(incomingSassOptions?.importers),
             url: pathToFileURL(filePath),
-            /** force sourceMap because right now rollup outputOptions are not available */
-            sourceMap: true,
+            /**
+             * Rollup output options are not available at transform time, so
+             * the user must opt in via the plugin's top-level `sourceMap`
+             * option. Defaults to `false` to avoid generating maps that the
+             * consumer never asked for.
+             */
+            sourceMap: wantsSourceMap,
           };
 
           /**
@@ -141,9 +147,10 @@ export = function plugin(
 
           return {
             code: codeResult || '',
-            map: sourceMap
-              ? (sourceMap as unknown as SourceMapInput)
-              : undefined,
+            map:
+              wantsSourceMap && sourceMap
+                ? (sourceMap as unknown as SourceMapInput)
+                : undefined,
           };
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,20 @@ interface RollupPluginSassSharedOptions {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   runtime?: any;
+
+  /**
+   * Whether the plugin should request a sourcemap from Sass and forward it to
+   * Rollup. Defaults to `false`.
+   *
+   * Rollup output options are not available at `transform` time, so the plugin
+   * cannot infer the desired sourcemap behavior from Rollup. Set this to `true`
+   * (in addition to enabling Rollup's own `output.sourcemap`) when you want the
+   * Sass-generated map to be returned alongside the compiled CSS.
+   *
+   * Only honored by the modern Sass API (`api: 'modern'`); the legacy API
+   * always emits a map when Sass produces one.
+   */
+  sourceMap?: boolean;
 }
 
 export type RollupPluginSassModernOptions = Omit<

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1088,6 +1088,95 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
   test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_LEGACY);
   test(title, macro, TEST_PLUGIN_OPTIONS_DEFAULT_MODERN);
 }
+
+// #region modern api sourceMap opt-in (#221)
+//
+// Issue #221: the modern Sass API path used to hardcode `sourceMap: true`
+// because Rollup output options aren't available at `transform` time. That
+// produced an inert `{ mappings: '' }`-style map even when the user hadn't
+// asked for one. The fix is to make sourcemap emission an explicit opt-in via
+// the plugin's top-level `sourceMap` option.
+test(
+  'modern api: plugin should not emit a sourcemap from transform when ' +
+    "the `sourceMap` plugin option isn't set",
+  async (t) => {
+    const capturedMaps: unknown[] = [];
+
+    const outputBundle = await rollup({
+      input: 'test/fixtures/basic/index.js',
+      plugins: [
+        sass({ api: 'modern' }),
+        {
+          name: 'capture-transform-map',
+          // Runs immediately after the sass plugin's transform; the `map`
+          // argument here is whatever the previous plugin returned.
+          transform(_code, id) {
+            if (/\.s[ac]ss$/.test(id)) {
+              const moduleInfo = this.getModuleInfo(id);
+              capturedMaps.push(moduleInfo?.meta);
+            }
+            return null;
+          },
+        },
+      ],
+    });
+
+    const { output } = await outputBundle.generate({
+      format: 'es',
+      file: path.join(
+        getTestOutputDir('modern'),
+        'modern-no-sourcemap-default.js',
+      ),
+      sourcemap: false,
+    });
+
+    t.falsy(
+      output[0].map,
+      "output chunk should not contain a `map` entry when neither rollup nor the plugin's `sourceMap` option asks for one",
+    );
+  },
+);
+
+test(
+  'modern api: plugin should emit a sourcemap from transform when ' +
+    'the `sourceMap` plugin option is true',
+  async (t) => {
+    const outputFilePath = path.join(
+      getTestOutputDir('modern'),
+      'modern-sourcemap-opt-in.js',
+    );
+
+    const bundle = await rollup({
+      input: 'test/fixtures/basic/index.js',
+      plugins: [sass({ api: 'modern', sourceMap: true })],
+    });
+
+    const sourceMapFilePath = `${outputFilePath}.map`;
+
+    const writeResult = await bundle.write({
+      file: outputFilePath,
+      sourcemap: true,
+      format: 'esm',
+    });
+
+    t.true(
+      !!writeResult.output?.length,
+      'output should contain an output chunk',
+    );
+
+    t.true(
+      !!writeResult.output[0].map,
+      "rollup output chunk's `map` property should be set",
+    );
+
+    const contents = await fs.readFile(sourceMapFilePath);
+    t.true(
+      !!contents.toString(),
+      `${sourceMapFilePath} should have been written.`,
+    );
+  },
+);
+// #endregion modern api sourceMap opt-in (#221)
 // #endregion sourcemap
 
 {


### PR DESCRIPTION
## Summary

Closes #221.

`src/index.ts` no longer hardcodes `sourceMap: true` in the modern Sass API path. The plugin now compiles sourcemaps when (and only when) the user opts in via a new top-level `sourceMap` plugin option.

### Approach

**Option A** (recommended in the issue). Added an explicit `sourceMap?: boolean` to `RollupPluginSassSharedOptions` (default `false`). It is forwarded into `compileStringAsync`'s options and used to gate the `map` value returned from `transform`. The modern API path's returned `map` is `undefined` when the option is not set, so we no longer produce a zombie `{ mappings: '' }` entry.

This was preferred over Option B (forwarding `incomingSassOptions?.sourceMap`) because:
- it surfaces the option at the same level as the other behavior flags (`insert`, `output`, etc.), which is more discoverable;
- it keeps the existing `Omit<'sourceMap'>` on `RollupPluginSassModernOptions` intact (no widening of the Sass option object).

### Why it's breaking

1. Users who don't explicitly set `sourceMap: true` will stop receiving sass-generated maps from the modern API path. Previously the plugin emitted them unconditionally.
2. The public `RollupPluginSassSharedOptions` shape gains a new property, which is additive but documented as a SemVer-major behavior change per #221.

### Migration

```diff
 sass({
   api: 'modern',
+  sourceMap: true,
   options: { /* ... */ },
 })
```

Combine with Rollup's own `output.sourcemap: true` to get an adjacent `.map` file.

## Test plan

- [x] `npm run lint:fix` clean
- [x] `npm run build` succeeds
- [x] `npm test` 59 tests passing, including two new modern-API cases:
  - `modern api: plugin should not emit a sourcemap from transform when the \`sourceMap\` plugin option isn't set`
  - `modern api: plugin should emit a sourcemap from transform when the \`sourceMap\` plugin option is true`