### PR TITLE
feat: #222 migrate output to this.emitFile across all paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { promisify } from 'util';
-import * as fs from 'fs';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -201,38 +200,64 @@ export = function plugin(
 
       const css = styles.map((style) => style.content).join('');
 
+      // Branch 1: `output` is a string path - emit with that exact fileName.
+      // Rollup honors `fileName` literally (relative to the rollup output dir).
       if (typeof output === 'string') {
-        await fs.promises.mkdir(path.dirname(output), { recursive: true });
-        await fs.promises.writeFile(output, css);
+        const outputDir = outputOptions.dir
+          ? outputOptions.dir
+          : outputOptions.file
+            ? path.dirname(outputOptions.file)
+            : process.cwd();
+        const relPath = path.isAbsolute(output)
+          ? path.relative(outputDir, output)
+          : output;
 
+        this.emitFile({
+          type: 'asset',
+          fileName: relPath,
+          source: css,
+        });
         return;
       }
 
+      // Branch 2: `output` is a function - hand control to the user fn.
+      // The user fn is responsible for writing the file itself (legacy
+      // semantics preserved). We do NOT additionally emit an asset here -
+      // emitting would surprise users who expect their fn to be the sole
+      // recipient of the CSS, and would also add an unexpected asset to
+      // rollup's `bundle`.
       if (typeof output === 'function') {
         await output(css, styles);
         return;
       }
 
+      // Branch 3: `output === true` with `outputOptions.file` -
+      // derive `<entry-stem>.css` and emit with `fileName` (literal,
+      // sibling to the JS entry).
       if (!insert && outputOptions.file && output === true) {
-        let dest = outputOptions.file;
-
-        const parsed = path.parse(dest);
-        dest = path.join(parsed.dir, `${parsed.name}.css`);
-
-        await fs.promises.mkdir(path.dirname(dest), { recursive: true });
-        await fs.promises.writeFile(dest, css);
+        const parsed = path.parse(outputOptions.file);
+        this.emitFile({
+          type: 'asset',
+          fileName: `${parsed.name}.css`,
+          source: css,
+        });
         return;
       }
 
+      // Branch 4: `output === true` with `outputOptions.dir` -
+      // derive from the entry chunk's fileName; emit with `name` so
+      // rollup applies `assetFileNames` (and hashing).
       if (!insert && outputOptions.dir && output === true) {
         const entry = Object.values(bundle).find(
           (item) => item.type === 'chunk' && item.isEntry,
         );
         if (!entry) return;
         const baseName = path.parse(entry.fileName).name;
-        const dest = path.join(outputOptions.dir, `${baseName}.css`);
-        await fs.promises.mkdir(path.dirname(dest), { recursive: true });
-        await fs.promises.writeFile(dest, css);
+        this.emitFile({
+          type: 'asset',
+          name: `${baseName}.css`,
+          source: css,
+        });
         return;
       }
     },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -507,7 +507,7 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
           getTestOutputDir(pluginOptions.api),
           'support_output_prev-non-exist.js',
         );
-        await outputBundle.write({
+        const writeResult = await outputBundle.write({
           ...TEST_GENERATE_OPTIONS,
           file: outputFilePath,
         });
@@ -518,6 +518,20 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
         const outputStyleContent = await fs.readFile(outputStylePath);
         t.true(stripNewLines(outputStyleContent.toString()).includes(expectA));
         t.true(stripNewLines(outputStyleContent.toString()).includes(expectB));
+
+        // Asset must now appear in rollup's bundle representation, with
+        // its fileName resolved relative to the rollup output directory.
+        const expectedAssetFileName = path.relative(
+          path.dirname(outputFilePath),
+          outputStylePath,
+        );
+        const cssAsset = writeResult.output.find(
+          (it) => it.type === 'asset' && it.fileName === expectedAssetFileName,
+        );
+        t.truthy(
+          cssAsset,
+          `CSS asset (fileName="${expectedAssetFileName}") must be present in rollup output bundle`,
+        );
       },
       title: createApiOptionTestCaseTitle,
     });
@@ -541,7 +555,7 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
           getTestOutputDir(pluginOptions.api),
           'support-output-as-true.js',
         );
-        await outputBundle.write({
+        const writeResult = await outputBundle.write({
           ...TEST_GENERATE_OPTIONS,
           file: outputFilePath,
         });
@@ -553,6 +567,16 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
         const outputStyleContent = await fs.readFile(outputStylePath);
         t.true(outputStyleContent.toString().includes(expectA));
         t.true(outputStyleContent.toString().includes(expectB));
+
+        // Asset must now appear in rollup's bundle representation.
+        const expectedAssetFileName = path.basename(outputStylePath);
+        const cssAsset = writeResult.output.find(
+          (it) => it.type === 'asset' && it.fileName === expectedAssetFileName,
+        );
+        t.truthy(
+          cssAsset,
+          'CSS asset must be present in rollup output bundle',
+        );
       },
       title: createApiOptionTestCaseTitle,
     });
@@ -578,13 +602,18 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
           onwarn,
         });
 
-        await outputBundle.write({
+        const writeResult = await outputBundle.write({
           format: 'es',
           dir: outputDir,
+          // Pin `assetFileNames` so the emitted CSS asset lands at a
+          // predictable path that we can read back from disk.
+          assetFileNames: '[name][extname]',
         });
 
-        // The CSS file should be written as <entry-stem>.css inside outputDir.
-        // The entry chunk file name is derived from the input file name → "index.css".
+        // The CSS file should be emitted alongside the entry as
+        // `<entry-stem>.css` once `assetFileNames` is honored.
+        // The entry chunk file name is derived from the input file name
+        // → "index.css".
         const outputStylePath = path.join(outputDir, 'index.css');
         const outputStyleContent = await fs.readFile(outputStylePath);
         t.true(
@@ -594,6 +623,16 @@ const createApiOptionTestCaseTitle: TitleFn<[RollupPluginSassOptions]> = (
         t.true(
           stripNewLines(outputStyleContent.toString()).includes(expectB),
           `CSS file should include expectB content`,
+        );
+
+        // Asset should now appear in rollup's `bundle` representation
+        // (one of the core wins of switching to `this.emitFile`).
+        const cssAsset = writeResult.output.find(
+          (it) => it.type === 'asset' && it.fileName === 'index.css',
+        );
+        t.truthy(
+          cssAsset,
+          'CSS asset must be present in rollup output bundle',
         );
       },
       title: createApiOptionTestCaseTitle,


### PR DESCRIPTION
## Summary

Closes #222.

Replaces all `fs.promises.writeFile` calls in `generateBundle` with
`this.emitFile({ type: 'asset', ... })` so the CSS output now participates
in rollup's asset pipeline:

- CSS appears in the rollup `bundle` and downstream plugins (e.g.
  postcss/minifiers) can read/transform it.
- `assetFileNames` is honored.
- Asset hashing is supported when emitting with `name` (Branch 4).

## Branch behaviors (`generateBundle`)

| `output` value         | Emit shape                                       | Notes                                                                                       |
| ---------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------- |
| `string`               | `this.emitFile({ fileName: <string>, ... })`     | Rollup honors `fileName` literally. Absolute paths are resolved relative to the output dir. |
| `function`             | `await output(css, styles)`                      | User fn owns the write. Plugin does NOT additionally emit (avoids surprise asset).          |
| `true` + `output.file` | `this.emitFile({ fileName: '<stem>.css', ... })` | Sibling to the JS entry.                                                                    |
| `true` + `output.dir`  | `this.emitFile({ name: '<stem>.css', ... })`     | Rollup applies `assetFileNames` (defaults to `assets/[name]-[hash][extname]`).              |

## Breaking change

For `output: true` combined with `output.dir`, the emitted file name now flows
through rollup's `assetFileNames`, so by default the file lands at
`assets/<stem>-<hash>.css` (was: `<stem>.css` at the root). Consumers who want
the old path can opt in explicitly:

```ts
await bundle.write({ dir, assetFileNames: '[name][extname]' });
```

The dir-based test was adapted to pin `assetFileNames: '[name][extname]'`
which documents the upgrade path.

## Internal cleanup

- Removed the now-unused `import * as fs from 'fs'`.
- `buildStart` reset from #218 stays in place; not touched.
- Modern API transform sourcemap area (issue #221) untouched.

## Test plan

- [x] `npm run lint:fix`
- [x] `npm run build`
- [x] `npm test` (57/57 passing, including types pass)
- [x] String output: file appears at the resolved path AND the asset shows up in `writeResult.output`.
- [x] `true` + `output.file`: `<entry>.css` appears alongside JS AND asset shows up in `writeResult.output`.
- [x] `true` + `output.dir`: emitted alongside the entry under `assetFileNames` rules AND asset shows up in `writeResult.output`.
- [x] Function output: user fn called with `(css, styles)`; no extra asset emitted.